### PR TITLE
readme-purpose: Add purpose to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,50 @@ This gem contains custom cops and additional tooling for Nulogy's implementation
 
 This functionaltiy is executed by the `bin/nucop` executable. If you installed the gem, it will be added to your path.
 
+## Purpose
+
+When integrating RuboCop into large existing project, it is likely that it will have an overwhelming number of offenses.
+To aid adoption, RuboCop can generate a `.rubocop_todo.yml` file to exclude existing violations.
+
+This presents two problems:
+
+* It is harder for developers to fix existing problems, since TODO violations are ignored
+* Cops with too many violations are disabled, so new violations can be introduced into the codebase
+
+Editors can help with the former. However, `nucop` provides a couple tools to help speed adoption:
+
+1. Enforced cops
+
+This is a new list of cops and/or departments that MUST not have violations.
+
+This is useful in CI if you do not want developers to add new `Layout/` violations, etc.
+
+Also, if `nucop regen_backlog` is used to regenerate the TODO file, any cops that had TODO violations,
+but no longer have vioations are automatically added to enforced cops list.
+
+2. `nucop modified_lines`
+
+This command will print ALL RuboCop violations (i.e. including TODO violations) for all code lines changes since some git SHA.
+
+This can be useful for local development, to increases visibility of existing violations during development cycles, but does
+not hold up code in CI.
+
+Finally, several custom cops are included, which may be application/framework/gem specific.
+
+## CLI Commands
+
+The [nucop CLI](lib/nucop/cli.rb) provides the following commands:
+
+| Command             | Description                                                                      |
+|---------------------|----------------------------------------------------------------------------------|
+| diff_enforced       | run RuboCop on the current diff using only the enforced cops                     |
+| diff                | run RuboCop on the current diff                                                  |
+| rubocop             | run RuboCop on files provided (without backlog by default)                       |
+| regen_backlog       | update the RuboCop backlog, updating enforced cops list                          |
+| update_enforced     | update the enforced cops list with file with cops that no longer have violations |
+| modified_lines      | display RuboCop violations for ONLY modified lines                               |
+| ready_for_promotion | display the next n cops with the fewest violations                               |
+
 ## Requirements
 
 Beyond a working Ruby installation and what is specified in the gemspec, we make some assumptions about your environment:


### PR DESCRIPTION
@amckinnell What do you think about this description?

Other teams may be interested and need to know why they would want to use `nucop`.