### PR TITLE
Add json format option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@
 /pkg/
 /spec/reports/
 /tmp/
-
-# rspec failure tracking
 .rspec_status
+.tool-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## master (unreleased)
 
+## 0.2.1 (2020-03-21)
+
+* Add `--json output.json` option to `diff_enforced`
+
 ## 0.2.0 (2020-01-18)
 
 * Latest versions of the various Rubocop gems
-

--- a/lib/nucop/cli.rb
+++ b/lib/nucop/cli.rb
@@ -75,7 +75,19 @@ module Nucop
         "--require rubocop-rails"
       ]
 
-      system("bundle exec rubocop --parallel #{rubocop_requires.join(' ')} #{junit_report_options} --force-exclusion --config #{config_file} #{pass_through_option(options, 'auto-correct')} #{pass_through_flag(options, 'only')} #{files}")
+      command = [
+        "bundle exec rubocop",
+        "--parallel",
+        rubocop_requires.join(" "),
+        junit_report_options,
+        "--force-exclusion",
+        "--config", config_file,
+        pass_through_option(options, "auto-correct"),
+        pass_through_flag(options, "only"),
+        files
+      ].join(" ")
+
+      system(command)
     end
 
     desc "regen_backlog", "update the RuboCop backlog, disabling offending files and excluding all cops with over 500 violating files."

--- a/lib/nucop/cli.rb
+++ b/lib/nucop/cli.rb
@@ -9,7 +9,7 @@ module Nucop
     desc "diff_enforced", "run RuboCop on the current diff using only the enforced cops"
     method_option "commit-spec", default: "origin/master", desc: "the commit used to determine the diff."
     method_option "auto-correct", type: :boolean, default: false, desc: "runs RuboCop with auto-correct option"
-    method_option "junit_report", type: :string, default: "", desc: "runs RuboCop with junit formatter option"
+    method_option "junit_report", type: :string, default: nil, desc: "runs RuboCop with junit formatter option"
     method_option "json", type: :string, default: nil, desc: "Output results as JSON format to the provided file"
     def diff_enforced
       invoke :diff, nil, options.merge(only: cops_to_enforce.join(","))

--- a/lib/nucop/version.rb
+++ b/lib/nucop/version.rb
@@ -1,3 +1,3 @@
 module Nucop
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
When I run `diff_enforced` I would like to also have a JSON formatted file created with the results.

e.g. `nucop diff_enforced --json rubocop.json`

See working with [multiple formatters](https://github.com/rubocop-hq/rubocop/blob/master/manual/formatters.md)