### PR TITLE
PM-11283 add GitHub file diff commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## main (unreleased)
 
+## 0.9.0 (2023-04-06)
+
+* Add 'diff_enforced_github' command
+* Add 'diff_github' command
+
 ## 0.8.0 (2023-03-16)
 
 * Deprecate 'auto-correct' option

--- a/README.md
+++ b/README.md
@@ -38,15 +38,17 @@ Finally, several custom cops are included, which may be application/framework/ge
 
 The [nucop CLI](lib/nucop/cli.rb) provides the following commands:
 
-| Command             | Description                                                                      |
-|---------------------|----------------------------------------------------------------------------------|
-| diff_enforced       | run RuboCop on the current diff using only the enforced cops                     |
-| diff                | run RuboCop on the current diff                                                  |
-| rubocop             | run RuboCop on files provided (without backlog by default)                       |
-| regen_backlog       | update the RuboCop backlog, updating enforced cops list                          |
-| update_enforced     | update the enforced cops list with file with cops that no longer have violations |
-| modified_lines      | display RuboCop violations for ONLY modified lines                               |
-| ready_for_promotion | display the next n cops with the fewest violations                               |
+| Command              | Description                                                                                              |
+|----------------------|----------------------------------------------------------------------------------------------------------|
+| diff_enforced        | run RuboCop on the current diff using only the enforced cops                                             |
+| diff_enforced_github | run RuboCop on the current diff using only the enforced cops (uses GitHub to determine the current diff) |
+| diff                 | run RuboCop on the current diff                                                                          |
+| diff_github          | run RuboCop on the current diff (uses GitHub to determine the current diff)                              |                                                                          |
+| rubocop              | run RuboCop on files provided (without backlog by default)                                               |
+| regen_backlog        | update the RuboCop backlog, updating enforced cops list                                                  |
+| update_enforced      | update the enforced cops list with file with cops that no longer have violations                         |
+| modified_lines       | display RuboCop violations for ONLY modified lines                                                       |
+| ready_for_promotion  | display the next n cops with the fewest violations                                                       |
 
 ## Requirements
 

--- a/lib/nucop/version.rb
+++ b/lib/nucop/version.rb
@@ -1,3 +1,3 @@
 module Nucop
-  VERSION = "0.8.0"
+  VERSION = "0.9.0"
 end


### PR DESCRIPTION
Adds the ability to use GitHub to work out the files to run RuboCop against.

- This allows us to use a shallow clone of the repository which is much faster in CI situations.