### PR TITLE
Filter Lint/RedundantCopDisableDirective cop from cops_to_enforce as it doesn't support being run under the --only flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+## 0.13.3 (2025-03-36)
+
+* Filter Lint/RedundantCopDisableDirective cop from cops_to_enforce as it doesn't support being run under the --only flag
+
 ## 0.13.2 (2025-03-19)
 
 * The rubocop-capybara gem is now a rubocop plugin

--- a/lib/nucop/cli.rb
+++ b/lib/nucop/cli.rb
@@ -280,6 +280,7 @@ module Nucop
       cops = enforced_cops
 
       cops.delete("Lint/UnneededCopDisableDirective")
+      cops.delete("Lint/RedundantCopDisableDirective")
 
       cops
     end

--- a/lib/nucop/version.rb
+++ b/lib/nucop/version.rb
@@ -1,3 +1,3 @@
 module Nucop
-  VERSION = "0.13.2"
+  VERSION = "0.13.3"
 end


### PR DESCRIPTION
- bump version to 0.13.3
